### PR TITLE
feat: Implement core Zaplink API with routes for file upload and retr…

### DIFF
--- a/src/Routes/zap.routes.ts
+++ b/src/Routes/zap.routes.ts
@@ -5,11 +5,27 @@ import {
   getZapByShortId,
   // shortenUrl,
 } from "../controllers/zap.controller";
+import {
+  uploadLimiter,
+  downloadLimiter,
+} from "../middlewares/rateLimiter";
 
 const router = express.Router();
 
-router.post("/upload", upload.single("file"), createZap);
+/**
+ * POST /api/zaps/upload
+ * Rate limit: 10 requests / min per IP  (uploadLimiter)
+ * Also triggers QR code generation — compute-heavy, kept strict.
+ */
+router.post("/upload", uploadLimiter, upload.single("file"), createZap);
+
+/**
+ * GET /api/zaps/:shortId
+ * Rate limit: 30 requests / min per IP  (downloadLimiter)
+ * Prevents bulk scraping / automated mass-download of shared content.
+ */
+router.get("/:shortId", downloadLimiter, getZapByShortId);
+
 // router.post("/shorten", (req, res) => shortenUrl(req, res));
-router.get("/:shortId", getZapByShortId);
 
 export default router;

--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -1,0 +1,73 @@
+import rateLimit from "express-rate-limit";
+import { Request, Response } from "express";
+
+/**
+ * Builds a consistent 429 Too Many Requests JSON response
+ * using the same ApiError shape used throughout the project.
+ */
+const tooManyRequestsHandler = (
+    req: Request,
+    res: Response,
+    _next: Function,
+    options: { message: string }
+) => {
+    res.status(429).json({
+        statusCode: 429,
+        message: options.message,
+        success: false,
+        errors: [],
+    });
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global API limiter
+// Applied to every /api/* route as a baseline.
+// Config: RATE_LIMIT_WINDOW_MS  (default: 15 min)
+//         RATE_LIMIT_MAX        (default: 100 requests)
+// ─────────────────────────────────────────────────────────────────────────────
+export const globalLimiter = rateLimit({
+    windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "") || 15 * 60 * 1000,
+    max: parseInt(process.env.RATE_LIMIT_MAX || "") || 100,
+    standardHeaders: true,   // Return rate limit info in RateLimit-* headers
+    legacyHeaders: false,    // Disable X-RateLimit-* legacy headers
+    message: "Too many requests. Please try again later.",
+    handler: tooManyRequestsHandler,
+    skip: (req) =>
+        req.path === "/favicon.ico" ||
+        req.path === "/" ||
+        req.path === "/health",
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Upload & QR generation limiter  (POST /api/zaps/upload)
+// Stricter because each request hits Cloudinary and generates a QR code.
+// Config: UPLOAD_RATE_LIMIT_WINDOW_MS  (default: 1 min)
+//         UPLOAD_RATE_LIMIT_MAX        (default: 10 requests)
+// ─────────────────────────────────────────────────────────────────────────────
+export const uploadLimiter = rateLimit({
+    windowMs:
+        parseInt(process.env.UPLOAD_RATE_LIMIT_WINDOW_MS || "") || 1 * 60 * 1000,
+    max: parseInt(process.env.UPLOAD_RATE_LIMIT_MAX || "") || 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message:
+        "Upload limit exceeded. You can upload at most 10 files per minute. Please wait and try again.",
+    handler: tooManyRequestsHandler,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Download / Zap-access limiter  (GET /api/zaps/:shortId)
+// Prevents bulk scraping / automated mass-download of shared content.
+// Config: DOWNLOAD_RATE_LIMIT_WINDOW_MS  (default: 1 min)
+//         DOWNLOAD_RATE_LIMIT_MAX        (default: 30 requests)
+// ─────────────────────────────────────────────────────────────────────────────
+export const downloadLimiter = rateLimit({
+    windowMs:
+        parseInt(process.env.DOWNLOAD_RATE_LIMIT_WINDOW_MS || "") || 1 * 60 * 1000,
+    max: parseInt(process.env.DOWNLOAD_RATE_LIMIT_MAX || "") || 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message:
+        "Too many download requests from this IP. Please slow down and try again in a minute.",
+    handler: tooManyRequestsHandler,
+});


### PR DESCRIPTION
## Team Number : Team 123

## Description
Implements rate limiting middleware across all ZapLink backend API endpoints to prevent abuse, spam, and potential DoS attacks. A global limiter is applied to all `/api/*` routes, with stricter per-route limiters on the sensitive file upload (+ QR generation) and file download/access endpoints. All limits are configurable via environment variables and return clear, consistent `429 Too Many Requests` responses.

## Related Issue
Closes #2 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Style/UI improvement

## Changes Made
- Created [src/middlewares/rateLimiter.ts](cci:7://file:///d:/Zaplink_backend/src/middlewares/rateLimiter.ts:0:0-0:0) with three configurable limiters: `globalLimiter`, `uploadLimiter`, and `downloadLimiter`
- Updated [src/index.ts](cci:7://file:///d:/Zaplink_backend/src/index.ts:0:0-0:0) to apply `globalLimiter` to all `/api/*` routes (replaces the previous inline limiter); utility routes `/`, `/health`, and `/favicon.ico` are excluded
- Updated [src/Routes/zap.routes.ts](cci:7://file:///d:/Zaplink_backend/src/Routes/zap.routes.ts:0:0-0:0) to apply `uploadLimiter` on `POST /api/zaps/upload` and `downloadLimiter` on `GET /api/zaps/:shortId`
- Added [.env.example](cci:7://file:///d:/Zaplink_backend/.env.example:0:0-0:0) documenting all six new rate-limit environment variables (`RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `UPLOAD_RATE_LIMIT_WINDOW_MS`, `UPLOAD_RATE_LIMIT_MAX`, `DOWNLOAD_RATE_LIMIT_WINDOW_MS`, `DOWNLOAD_RATE_LIMIT_MAX`)
- All `429` responses use the same `{ statusCode, message, success, errors }` shape as the existing [ApiError](cci:2://file:///d:/Zaplink_backend/src/utils/ApiError.ts:0:0-33:3) class for consistency

## Screenshots (if applicable)
N/A — backend-only change (no UI)

**Before:**
No route-specific rate limiting. Only a partial inline global limiter existed in [index.ts](cci:7://file:///d:/Zaplink_backend/src/index.ts:0:0-0:0) with no env-variable support and no consistent error response format.

**After:**
| Route | Limit |
|---|---|
| All `/api/*` routes | 100 requests / 15 min per IP |
| `POST /api/zaps/upload` | 10 requests / 1 min per IP |
| `GET /api/zaps/:shortId` | 30 requests / 1 min per IP |

Exceeding any limit returns:
```json
{
  "statusCode": 429,
  "message": "Too many requests. Please try again later.",
  "success": false,
  "errors": []
}
```

## Testing
- [ ] Tested on Desktop (Chrome/Firefox/Safari)
- [ ] Tested on Mobile (iOS/Android)
- [ ] Tested responsive design (different screen sizes)
- [x] No console errors or warnings
- [x] Code builds successfully (`npm run build`)

> **Manual test steps:**
> 1. Run `npm run dev` and send 11+ rapid `POST /api/zaps/upload` requests using Postman/curl — 11th request should return `HTTP 429` with the error message above.
> 2. Send 31+ rapid `GET /api/zaps/:shortId` requests — 31st should return `HTTP 429`.
> 3. Send 101+ rapid requests to any other `/api/*` route within 15 minutes — limit kicks in at request 101.
> 4. Check response headers for `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` (standard headers are enabled).

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] All TypeScript types are properly defined
- [ ] Tailwind CSS classes are used appropriately (no inline styles)
- [ ] Component is responsive across different screen sizes
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
- `express-rate-limit` v7.5.1 was already listed as a dependency in [package.json](cci:7://file:///d:/Zaplink_backend/package.json:0:0-0:0) — **no new packages were installed**.
- `app.set("trust proxy", 1)` is already set in [index.ts](cci:7://file:///d:/Zaplink_backend/src/index.ts:0:0-0:0), which is required for accurate IP detection when deployed behind a reverse proxy (Render, Vercel, Nginx, etc.).
- All six rate-limit values are **fully configurable via `.env`** — no code changes needed to tune limits for production vs. staging environments.