### PR TITLE
fix: replace plaintext password comparison with bcrypt.compare() in F…

### DIFF
--- a/src/controllers/FileController.ts
+++ b/src/controllers/FileController.ts
@@ -44,9 +44,21 @@ export class FileController {
         });
       }
 
-      if (file.password && file.password !== password) {
-        res.status(401).json({ error: "Invalid password" });
-        return;
+      if (file.password) {
+        if (!password) {
+          res.status(401).json({ error: "Password required" });
+          return;
+        }
+
+        const isPasswordValid = await bcrypt.compare(
+          password as string,
+          file.password
+        );
+
+        if (!isPasswordValid) {
+          res.status(401).json({ error: "Invalid password" });
+          return;
+        }
       }
       const updatedFile = await prisma.file.update({
         where: { zapId },


### PR DESCRIPTION
**Team Number:** Team 188

## Description
In [src/controllers/FileController.ts](cci:7://file:///c:/Users/dhruv/Desktop/open%20source/zaplink%20backend/Zaplink_backend/src/controllers/FileController.ts:0:0-0:0) (line 47), the [getFile](cci:1://file:///c:/Users/dhruv/Desktop/open%20source/zaplink%20backend/Zaplink_backend/src/controllers/FileController.ts:11:2-89:3) method was comparing passwords using a direct `!==` string comparison instead of `bcrypt.compare()`. This is a security vulnerability — either passwords are stored as plaintext, or the comparison always fails against hashed passwords.

### Changes Made
- Replaced `file.password !== password` with `bcrypt.compare(password, file.password)` for secure hashed password verification
- Added an explicit check for missing password before attempting comparison
- Now consistent with how [zap.controller.ts](cci:7://file:///c:/Users/dhruv/Desktop/open%20source/zaplink%20backend/Zaplink_backend/src/controllers/zap.controller.ts:0:0-0:0) handles password authentication

## Related Issue
Fixes #20