### PR TITLE
Password & Access Control Bypass via Predictable Cloudinary URLs - T102

### DIFF
--- a/src/middlewares/upload.ts
+++ b/src/middlewares/upload.ts
@@ -1,29 +1,31 @@
 import multer from "multer";
 import { CloudinaryStorage } from "multer-storage-cloudinary";
 import cloudinary from "./cloudinary";
+import { customAlphabet } from "nanoid";
+
+const nanoid = customAlphabet("1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 12);
 
 const storage = new CloudinaryStorage({
   cloudinary: cloudinary,
-  params : (req , file) => {
+  params: (req, file) => {
     const fileName = file?.originalname;
     const ext = fileName.substring(fileName.lastIndexOf('.'));
-    const baseName = fileName.substring(0 , fileName.lastIndexOf('.'));
 
-    const {type} = req.body; 
+    const { type } = req.body;
     let resource_type = "raw";
 
-    if(type === "IMAGE" || type === "PDF"){
+    if (type === "IMAGE" || type === "PDF") {
       resource_type = "image";
-    }else if(type === "VIDEO"){
+    } else if (type === "VIDEO") {
       resource_type = "video";
-    }else{
+    } else {
       resource_type = "raw"
     }
 
     return {
-      folder : 'zaplink_folders',
+      folder: 'zaplink_folders',
       resource_type,
-      public_id : `${baseName}_${Date.now()}${ext}`
+      public_id: `${nanoid()}${ext}`
     }
   }
 });


### PR DESCRIPTION
## Team Number : 102
## Description
<!-- Provide a brief description of what this PR does -->
Replaces the predictable Cloudinary `public_id` (original filename + Unix timestamp) with a cryptographically secure `nanoid(12)` random string. This prevents attackers from guessing file URLs to bypass password protection, expiration controls, or overwriting other users' files.
## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #25
## Type of Change
<!-- Please check the relevant option(s) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement
## Changes Made
<!-- List the specific changes you made -->
- Modified [src/middlewares/upload.ts](cci:7://file:///d:/GDG%20Task/Zaplink_backend/src/middlewares/upload.ts:0:0-0:0) in the `CloudinaryStorage` params
- Replaced `${baseName}_${Date.now()}${ext}` with `${nanoid()}${ext}` as the `public_id`
- Removed `baseName` variable — original filename is no longer exposed in the Cloudinary URL

<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on Desktop (Chrome/Firefox/Safari)
- [ ] Tested on Mobile (iOS/Android)
- [ ] Tested responsive design (different screen sizes)
- [x] No console errors or warnings
- [x] Code builds successfully (`npm run build`)
## Checklist
<!-- Mark completed items with [x] -->
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] All TypeScript types are properly defined
- [ ] Tailwind CSS classes are used appropriately (no inline styles)
- [ ] Component is responsive across different screen sizes
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
