### PR TITLE
fix: maxViews column in atomic viewCount update

### DIFF
--- a/src/controllers/zap.controller.ts
+++ b/src/controllers/zap.controller.ts
@@ -496,7 +496,7 @@ export const getZapByShortId = async (
       UPDATE "Zap"
       SET "viewCount" = "viewCount" + 1, "updatedAt" = NOW()
       WHERE "shortId" = ${shortId}
-        AND ("viewLimit" IS NULL OR "viewCount" < "viewLimit")
+        AND ("maxViews" IS NULL OR "viewCount" < "maxViews")
     `;
 
     if (updateResult === 0) {


### PR DESCRIPTION
Fixes GET /api/zaps/:shortId returning 500 due to raw SQL referencing non-existent "viewLimit" column (DB column is "maxViews" via Prisma @map).\n\n- Updates the atomic viewCount increment query to use "maxViews"\n- Verified locally: create TEXT zap -> GET returns decrypted content